### PR TITLE
Added reverse mol index to convert mol_nlist to in molecule indices

### DIFF
--- a/htf/__init__.py
+++ b/htf/__init__.py
@@ -3,7 +3,8 @@
 
 # need to import md to have library available.
 import hoomd.md
-from .tfcompute import tfcompute
+# import make reverse for testing purposes
+from .tfcompute import tfcompute, _make_reverse_indices
 from .graphbuilder import graph_builder
 from .tfarraycomm import tf_array_comm
 from .utils import *

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -296,14 +296,20 @@ class graph_builder:
         is determined at run time. The MN must be chosen to be large enough to
         encompass all molecules. If your molecule is 6 atoms and you chose MN=18,
         then the extra entries will be zeros. Note that your input should be 0 based,
-        but subsequent tensorflow data will be 1 based, since 0 means no atom. The specification of what is a molecule
+        but subsequent tensorflow data will be 1 based, since 0 means no atom. 
+        The specification of what is a molecule
         will be passed at runtime, so that it can be dynamic if desired.
 
         To convert a _mol quantity to a per-particle quantity, call
         scatter_mol_quanitity(tensor)
         '''
-        self.mol_indices = tf.placeholder(tf.int32, shape=[None, MN], name='htf-molecule-index')
-        self.rev_mol_indices = tf.placeholder(tf.int32, shape=[None, 2], name='htf-reverse-molecule-index')
+
+        self.mol_indices = tf.placeholder(tf.int32, 
+                                          shape=[None, MN], 
+                                          name='htf-molecule-index')
+        self.rev_mol_indices = tf.placeholder(tf.int32, 
+                                              shape=[None, 2], 
+                                              name='htf-reverse-molecule-index')
         self.mol_flat_idx = tf.reshape(self.mol_indices, shape=[-1])
         ap = tf.concat((
                 tf.constant([0, 0, 0, 0], dtype=self.positions.dtype, shape=(1, 4)),

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -296,7 +296,7 @@ class graph_builder:
         is determined at run time. The MN must be chosen to be large enough to
         encompass all molecules. If your molecule is 6 atoms and you chose MN=18,
         then the extra entries will be zeros. Note that your input should be 0 based,
-        but subsequent tensorflow data will be 1 based, since 0 means no atom. 
+        but subsequent tensorflow data will be 1 based, since 0 means no atom.
         The specification of what is a molecule
         will be passed at runtime, so that it can be dynamic if desired.
 
@@ -304,11 +304,11 @@ class graph_builder:
         scatter_mol_quanitity(tensor)
         '''
 
-        self.mol_indices = tf.placeholder(tf.int32, 
-                                          shape=[None, MN], 
+        self.mol_indices = tf.placeholder(tf.int32,
+                                          shape=[None, MN],
                                           name='htf-molecule-index')
-        self.rev_mol_indices = tf.placeholder(tf.int32, 
-                                              shape=[None, 2], 
+        self.rev_mol_indices = tf.placeholder(tf.int32,
+                                              shape=[None, 2],
                                               name='htf-reverse-molecule-index')
         self.mol_flat_idx = tf.reshape(self.mol_indices, shape=[-1])
         ap = tf.concat((

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -507,6 +507,25 @@ class test_mol_batching(unittest.TestCase):
             tfcompute.attach(mol_indices=[[0, 1, 2], [3, 4], [5, 6, 7], [8]])
             hoomd.run(8)
 
+    def test_reverse_mol_index(self):
+        # need this for logging
+        hoomd.context.initialize()
+        mi = [[1, 2, 0, 0, 0], [3, 0, 0, 0, 0], [4, 5, 7, 8, 9]]
+        rmi = hoomd.htf._make_reverse_indices(mi)
+        # should be
+        rmi_ref = [
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [2, 0],
+            [2, 1],
+            [-1, -1],
+            [2, 2],
+            [2, 3],
+            [2, 4]
+        ]
+        self.assertEqual(rmi, rmi_ref)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/htf/tfcompute.py
+++ b/htf/tfcompute.py
@@ -126,6 +126,8 @@ class tfcompute(hoomd.compute._compute):
                                      'Increase MN in your graph.')
                 while len(mi) < self.graph_info['MN']:
                     mi.append(0)
+            # now make reverse
+            self.rev_mol_indices = _make_reverse_indices(self.mol_indices)
         else:
             self.mol_indices = None
 
@@ -207,7 +209,6 @@ class tfcompute(hoomd.compute._compute):
             self.cpp_force.addReferenceForce(f.cpp_force)
             hoomd.context.msg.notice(5, 'Will use given force for '
                                      'TFCompute {} \n'.format(f.name))
-
     def rcut(self):
         # adapted from hoomd/md/pair.py
         # go through the list of only the active particle types in the sim
@@ -287,6 +288,7 @@ class tfcompute(hoomd.compute._compute):
         fd = {'htf-batch-index:0': batch_index, 'htf-batch-frac:0': batch_frac}
         if self.mol_indices is not None:
             fd[self.graph_info['mol_indices']] = self.mol_indices
+            fd[self.graph_info['rev_mol_indices']] = self.rev_mol_indices
         if self.feed_dict is not None:
             if type(self.feed_dict) == dict:
                 value = self.feed_dict
@@ -325,3 +327,26 @@ class tfcompute(hoomd.compute._compute):
             npa[i, 2] = e.z
             npa[i, 3] = e.w
         return npa
+
+
+def _make_reverse_indices(mol_indices):
+    num_atoms = 0
+    for m in mol_indices:
+        num_atoms = max(num_atoms, max(m))
+    # add 1, since we found the largest index
+    num_atoms += 1
+    rmi = [[] for _ in range(num_atoms)]
+    for i in range(len(mol_indices)):
+        for j in range(len(mol_indices[i])):
+            index = mol_indices[i][j]
+            if index > 0:
+                rmi[index - 1] = [i, j]
+    warned = False
+    for r in rmi:
+        if len(r) != 2 and not warned:
+            warned = True
+            hoomd.context.msg.notice(
+                1,
+                'Not all of your atoms are in a molecule\n')
+            r.extend([-1, -1])
+    return rmi


### PR DESCRIPTION
This makes it possible to convert from an atom index to a molecule index, using a new graphbuilder attributed `rev_mol_index`. 