### PR TITLE
Added check for compiler version match in installation process

### DIFF
--- a/htf/CMakeLists.txt
+++ b/htf/CMakeLists.txt
@@ -18,12 +18,16 @@ set(_${COMPONENT_NAME}_cu_sources
     TFArrayComm.cu
     )
 
-# check if we have python dependencies for compiling
+  # check if we have python dependencies for compiling
+  set(TF_REQUIRE_COMPILER "")
+  if(NOT IGNORE_HTF_COMPILER)
+    set(TF_REQUIRE_COMPILER ${CMAKE_CXX_COMPILER_VERSION})
+  endif()
 set(TF_REQUIRE_VERSION "1.12")
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_tf_version.py ${TF_REQUIRE_VERSION}
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -W ignore ${CMAKE_CURRENT_SOURCE_DIR}/check_tf_version.py ${TF_REQUIRE_VERSION} ${TF_REQUIRE_COMPILER}
     RESULT_VARIABLE ret)
 if(ret EQUAL "1")
-    message(FATAL_ERROR "Could not find suitable tensorflow version to build ${COMPONENT_NAME}")
+    message(FATAL_ERROR "-- Could not find suitable tensorflow or compiler to build ${COMPONENT_NAME} (see messages above)")
 else()
     message("-- Found suitable tensorflow version for minimum ${TF_REQUIRE_VERSION}")
 endif()

--- a/htf/check_tf_version.py
+++ b/htf/check_tf_version.py
@@ -16,11 +16,13 @@ if len(sys.argv) == 3 and len(sys.argv[2]) > 1:
     vcomp_req = parse_version(sys.argv[2])
 
     if vcomp.base_version.split('.')[0] != vcomp_req.base_version.split('.')[0]:
-        print('-- Error: tensorflow was compiled with compiler version {} but you are trying to build with {} (major mismatch). To force compilation add IGNORE_HTF_COMPILER flag'.format(vcomp, vcomp_req))
+        print('-- Error: tensorflow was compiled with compiler version {} '
+              'but you are trying to build with {} (major mismatch). To force'
+              'compilation add IGNORE_HTF_COMPILER flag'.format(vcomp, vcomp_req))
         exit(1)
     elif vcomp != vcomp_req:
-        print('-- Warning: tensorflow was compiled with compiler version {} but you are trying to build with {} (minor mismatch)'.format(vcomp, vcomp_req))
-    
+        print('-- Warning: tensorflow was compiled with compiler version {} '
+              'but you are trying to build with {} (minor mismatch)'.format(vcomp, vcomp_req))
 
 # get and parse the version of the detected TF version
 vtf = parse_version(tensorflow.__version__)

--- a/htf/check_tf_version.py
+++ b/htf/check_tf_version.py
@@ -1,14 +1,26 @@
 R""" Check to ensure that we have a compatible version of TensorFlow.
-"""
+1;5202;0c"""
 
 from __future__ import print_function
 import sys
 try:
     import tensorflow
 except ImportError:
-    print('Error: Could not find tensorflow')
+    print('-- Error: Could not find tensorflow')
     exit(1)
 from pkg_resources import parse_version
+
+# Ensure copmiler versions match
+if len(sys.argv) == 3 and len(sys.argv[2]) > 1:
+    vcomp = parse_version(tensorflow.__compiler_version__)
+    vcomp_req = parse_version(sys.argv[2])
+
+    if vcomp.base_version.split('.')[0] != vcomp_req.base_version.split('.')[0]:
+        print('-- Error: tensorflow was compiled with compiler version {} but you are trying to build with {} (major mismatch). To force compilation add IGNORE_HTF_COMPILER flag'.format(vcomp, vcomp_req))
+        exit(1)
+    elif vcomp != vcomp_req:
+        print('-- Warning: tensorflow was compiled with compiler version {} but you are trying to build with {} (minor mismatch)'.format(vcomp, vcomp_req))
+    
 
 # get and parse the version of the detected TF version
 vtf = parse_version(tensorflow.__version__)
@@ -18,5 +30,5 @@ vreq = parse_version(sys.argv[1])
 if vtf.base_version.split('.')[0] == vreq.base_version.split('.')[0]:
     if vtf >= vreq:
         exit()
-print('Error: tensorflow version incompatible. Found', vtf, 'but need', vreq)
+print('-- Error: tensorflow version incompatible. Found', vtf, 'but need', vreq)
 exit(1)

--- a/htf/hoomd2tf_op/CMakeLists.txt
+++ b/htf/hoomd2tf_op/CMakeLists.txt
@@ -10,8 +10,8 @@ set(_${SUB_COMPONENT_NAME}_cu_sources
 
 
 #get TF specific compiler flags
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_compile_flags()))" OUTPUT_VARIABLE TF_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_link_flags()))" OUTPUT_VARIABLE TF_LFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -W ignore -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_compile_flags()))" OUTPUT_VARIABLE TF_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -W ignore -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_link_flags()))" OUTPUT_VARIABLE TF_LFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 #separate flags
 SEPARATE_ARGUMENTS( TF_CFLAGS )

--- a/htf/tf2hoomd_op/CMakeLists.txt
+++ b/htf/tf2hoomd_op/CMakeLists.txt
@@ -10,8 +10,8 @@ set(_${SUB_COMPONENT_NAME}_cu_sources
 
 
 #get TF specific compiler flags
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_compile_flags()))" OUTPUT_VARIABLE TF_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_link_flags()))" OUTPUT_VARIABLE TF_LFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -W ignore -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_compile_flags()))" OUTPUT_VARIABLE TF_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -W ignore -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_link_flags()))" OUTPUT_VARIABLE TF_LFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 #separate flags
 SEPARATE_ARGUMENTS( TF_CFLAGS )


### PR DESCRIPTION
This addresses Issue #129 which was a big problem for the bluehive process (compiler version mismatch). Please check by ensure compilation succeeds and then try loading an incorrect gcc module (e.g., the default) to ensure that CMake fails. 