### PR TITLE
Make cmake instructions consistent

### DIFF
--- a/sphinx-docs/source/compilation.rst
+++ b/sphinx-docs/source/compilation.rst
@@ -117,7 +117,7 @@ tensorflow. Here are steps **after** installing hoomd-blue
 
     git clone https://github.com/ur-whitelab/hoomd-tf
     cd hoomd-tf && mkdir build && cd build
-    cmake ..
+    CXX=g++ CC=gcc cmake ..
     make install
 
 That's it! Make sure you have a GCC compiler consistent with the
@@ -157,7 +157,7 @@ necessary. Set build type to `DEBUG` if you need to troubleshoot.
 .. code:: bash
 
     mkdir build && cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release \
+    CXX=g++ CC=gcc cmake .. -DCMAKE_BUILD_TYPE=Release \
      -DENABLE_CUDA=ON -DENABLE_MPI=OFF\
      -DBUILD_HPMC=off -DBUILD_CGCMM=off -DBUILD_MD=on\
      -DBUILD_METAL=off -DBUILD_TESTING=off -DBUILD_DEPRECATED=off -DBUILD_MPCD=OFF \
@@ -195,7 +195,7 @@ conda. The following additional flags can help with this:
 .. code:: bash
 
     export CMAKE_PREFIX_PATH=/path/to/environment
-    cmake .. \
+    CXX=g++ CC=gcc cmake .. \
     -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
     -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
     -DPYTHON_EXECUTABLE=$(which python) \


### PR DESCRIPTION
Our previous compilation instructions were inconsistent with specifying which compiler to use. This adds that throughout the compile instructions.