### PR TITLE
rm files after tests

### DIFF
--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -60,7 +60,7 @@ class test_mpi(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()

--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -6,7 +6,9 @@ from hoomd import init
 import unittest
 import build_examples
 import numpy as np
-
+import os
+import shutil
+from tmpFileTracker import tmpFileTracker
 
 def run_tf_lj(N, T):
     model_dir = build_examples.lj_graph(N - 1)
@@ -53,6 +55,17 @@ def run_hoomd_lj(N, T):
 
 
 class test_mpi(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_lj_forces(self):
         # need to be big enough for MPI testing
         # Needs to be perfect square

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -14,7 +14,8 @@ import numpy as np
 import math
 import tensorflow as tf
 import build_examples
-
+import shutil
+from tmpFileTracker import tmpFileTracker
 
 def compute_forces(system, rcut):
     '''1 / r^2 force'''
@@ -35,6 +36,17 @@ def compute_forces(system, rcut):
 
 
 class test_access(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_access(self):
         model_dir = build_examples.simple_potential()
         with hoomd.htf.tfcompute(model_dir,
@@ -64,6 +76,17 @@ class test_access(unittest.TestCase):
             assert len(np.unique(pa[:, 3].astype(np.int))) == 3
 
 class test_compute(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_force_overwrite(self):
         model_dir = build_examples.simple_potential()
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
@@ -484,6 +507,17 @@ class test_compute(unittest.TestCase):
 
 
 class test_mol_batching(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_single_atom(self):
         hoomd.context.initialize()
         model_dir = build_examples.lj_mol(9 - 1, 8)

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -41,7 +41,7 @@ class test_access(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()
@@ -81,7 +81,7 @@ class test_compute(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()
@@ -512,7 +512,7 @@ class test_mol_batching(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()

--- a/htf/test-py/test_utils.py
+++ b/htf/test-py/test_utils.py
@@ -4,9 +4,23 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import build_examples
+import os
+import shutil
+from tmpFileTracker import tmpFileTracker
 
 
 class test_loading(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_load_variables(self):
         model_dir = '/tmp/test-load'
         # make model that does assignment
@@ -32,6 +46,8 @@ class test_loading(unittest.TestCase):
 
 class test_mappings(unittest.TestCase):
     def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
         # build system using example from hoomd
         hoomd.context.initialize()
         snapshot = hoomd.data.make_snapshot(N=10,
@@ -53,6 +69,13 @@ class test_mappings(unittest.TestCase):
                                    [6, 7], [7, 8], [8, 9]]
         snapshot.replicate(1, 3, 3)
         self.system = hoomd.init.read_snapshot(snapshot)
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
 
     def test_find_molecules(self):
         # test out mapping
@@ -232,6 +255,17 @@ class test_mappings(unittest.TestCase):
 
 
 class test_bias(unittest.TestCase):
+    def setUp(self):
+        self.tracker = tmpFileTracker('/tmp')
+        self.tracker.pre_walk()
+
+    def tearDown(self):
+        if self.tracker == None:
+            print('Set-up Failed')
+        self.tracker.post_walk()
+        self.tracker.rm_tracked_files()
+        self.tracker = None
+
     def test_eds(self):
         T = 1000
         hoomd.context.initialize()

--- a/htf/test-py/test_utils.py
+++ b/htf/test-py/test_utils.py
@@ -15,7 +15,7 @@ class test_loading(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()
@@ -71,7 +71,7 @@ class test_mappings(unittest.TestCase):
         self.system = hoomd.init.read_snapshot(snapshot)
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()
@@ -260,7 +260,7 @@ class test_bias(unittest.TestCase):
         self.tracker.pre_walk()
 
     def tearDown(self):
-        if self.tracker == None:
+        if self.tracker is None:
             print('Set-up Failed')
         self.tracker.post_walk()
         self.tracker.rm_tracked_files()

--- a/htf/test-py/tmpFileTracker.py
+++ b/htf/test-py/tmpFileTracker.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+
+class tmpFileTracker:
+    ''' Track tmp files created during test and remove those files'''
+    
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+
+    def pre_walk(self):
+        self.pre_list = []
+        for root, dirs, files in os.walk(self.root_dir):
+            for name in dirs:
+                self.pre_list.append(os.path.join(root, name))
+        return self
+
+    def post_walk(self):    
+        self.post_list = []
+        for root, dirs, files in os.walk(self.root_dir):
+            for name in dirs: 
+                self.post_list.append(os.path.join(root, name))
+        return self
+
+    def rm_tracked_files(self):
+        diff = list(set(self.post_list).difference(set(self.pre_list)))
+        for item in diff:
+            path = os.path.join(self.root_dir, item)
+            shutil.rmtree(path)
+        return self


### PR DESCRIPTION
**1)** **Created a new file called "_tmpFilesTracker.py_" including a new class _tmpFilesTracker(root_dir)_
Three methods:**

    tmpFilesTracker.pre_walk()
    tmpFilesTracker.post_walk()
    tmpFilesTracker.rm_test_files()

**2)** **add _setUp(self)_ & _tearDown(self)_ in each unittest class:**

    def setUp(self):
            self.tracker = tmpFileTracker('/tmp')  //build a tracker everytime setUp() is called
            self.tracker.pre_walk()  //go through /tmp and memorize current dirs

    def tearDown(self):
             if self.tracker == None:                                                                                
                 print('Set-up Failed')                                                                            
             self.tracker.post_walk()   //go through the root_dir **again** and memorize current dirs                                                                           
             self.tracker.rm_tracked_files()   //remove dirs generated after test                                                                    
             self.tracker = None  // initialize tracker
    
