### PR TITLE
rm-files-after-test

### DIFF
--- a/htf/test-py/build_examples.py
+++ b/htf/test-py/build_examples.py
@@ -30,7 +30,7 @@ def simple_potential(directory='/tmp/test-simple-potential-model'):
                                                             ]).shape[1] == 4
 
 
-def benchmark_gradient_potential(directory = '/tmp/benchmark-gradient-potential-model'):
+def benchmark_gradient_potential(directory='/tmp/benchmark-gradient-potential-model'):
     graph = htf.graph_builder(1024, 64)
     nlist = graph.nlist[:, :, :3]
     # get r

--- a/htf/test-py/build_examples.py
+++ b/htf/test-py/build_examples.py
@@ -30,7 +30,7 @@ def simple_potential(directory='/tmp/test-simple-potential-model'):
                                                             ]).shape[1] == 4
 
 
-def benchmark_gradient_potential():
+def benchmark_gradient_potential(directory = '/tmp/benchmark-gradient-potential-model'):
     graph = htf.graph_builder(1024, 64)
     nlist = graph.nlist[:, :, :3]
     # get r
@@ -39,10 +39,10 @@ def benchmark_gradient_potential():
     energy = tf.reduce_sum(graph.safe_div(1., r), axis=1)
     forces = graph.compute_forces(energy)
     graph.save(force_tensor=forces,
-               model_directory='/tmp/benchmark-gradient-potential-model')
+               model_directory=directory)
 
 
-def gradient_potential():
+def gradient_potential(directory='/tmp/test-gradient-potential-model'):
     graph = htf.graph_builder(9 - 1)
     with tf.name_scope('force-calc') as scope:
         nlist = graph.nlist[:, :, :3]
@@ -52,7 +52,7 @@ def gradient_potential():
                                       name='energy')
     forces = graph.compute_forces(energy)
     graph.save(force_tensor=forces,
-               model_directory='/tmp/test-gradient-potential-model',
+               model_directory=directory,
                out_nodes=[energy])
 
 

--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -9,7 +9,7 @@ import numpy as np
 import tempfile
 
 
-def run_tf_lj(N, T, directory = '/tmp/test-lj-potential-model'):
+def run_tf_lj(N, T, directory='/tmp/test-lj-potential-model'):
     model_dir = build_examples.lj_graph(N - 1, directory)
     with hoomd.htf.tfcompute(model_dir,
                                            _mock_mode=False) as tfcompute:

--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -54,10 +54,10 @@ def run_hoomd_lj(N, T):
 
 class test_mpi(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_lj_forces(self):
         # need to be big enough for MPI testing

--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -6,10 +6,10 @@ from hoomd import init
 import unittest
 import build_examples
 import numpy as np
+import tempfile
 
-
-def run_tf_lj(N, T):
-    model_dir = build_examples.lj_graph(N - 1)
+def run_tf_lj(N, T, directory = '/tmp/test-lj-potential-model'):
+    model_dir = build_examples.lj_graph(N - 1, directory)
     with hoomd.htf.tfcompute(model_dir,
                                            _mock_mode=False) as tfcompute:
         rcut = 5.0
@@ -53,6 +53,12 @@ def run_hoomd_lj(N, T):
 
 
 class test_mpi(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryFile()
+
+    def tearDown(self):
+        self.tmp.close()
+
     def test_lj_forces(self):
         # need to be big enough for MPI testing
         # Needs to be perfect square
@@ -64,7 +70,7 @@ class test_mpi(unittest.TestCase):
             with self.subTest(decomp=p):
                 hoomd.context.initialize()
                 comm.decomposition(**p)
-                tf_forces = run_tf_lj(N, T)
+                tf_forces = run_tf_lj(N, T, self.tmp)
                 hoomd.context.initialize()
                 comm.decomposition(**p)
                 hoomd_forces = run_hoomd_lj(N, T)

--- a/htf/test-py/test_mpi_tensorflow.py
+++ b/htf/test-py/test_mpi_tensorflow.py
@@ -8,6 +8,7 @@ import build_examples
 import numpy as np
 import tempfile
 
+
 def run_tf_lj(N, T, directory = '/tmp/test-lj-potential-model'):
     model_dir = build_examples.lj_graph(N - 1, directory)
     with hoomd.htf.tfcompute(model_dir,

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -35,8 +35,14 @@ def compute_forces(system, rcut):
 
 
 class test_access(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryFile()
+
+    def tearDown(self):
+        self.tmp.close()
+
     def test_access(self):
-        model_dir = build_examples.simple_potential()
+        model_dir = build_examples.simple_potential(self.tmp)
         with hoomd.htf.tfcompute(model_dir,
                                  _mock_mode=True) as tfcompute:
             hoomd.context.initialize()
@@ -64,8 +70,14 @@ class test_access(unittest.TestCase):
             assert len(np.unique(pa[:, 3].astype(np.int))) == 3
 
 class test_compute(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryFile()
+
+    def tearDown(self):
+        self.tmp.close()
+
     def test_force_overwrite(self):
-        model_dir = build_examples.simple_potential()
+        model_dir = build_examples.simple_potential(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -91,7 +103,7 @@ class test_compute(unittest.TestCase):
                 hoomd.run(100)
 
     def test_nonlist(self):
-        model_dir = build_examples.benchmark_nonlist_graph()
+        model_dir = build_examples.benchmark_nonlist_graph(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             system = hoomd.init.create_lattice(
@@ -105,7 +117,7 @@ class test_compute(unittest.TestCase):
 
     def test_full_batch(self):
         hoomd.context.initialize()
-        model_dir = build_examples.benchmark_nonlist_graph()
+        model_dir = build_examples.benchmark_nonlist_graph(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             system = hoomd.init.create_lattice(unitcell=hoomd.lattice.sq(a=4.0),
                                                n=[32, 32])
@@ -116,7 +128,7 @@ class test_compute(unittest.TestCase):
 
     def test_write_empty_tensorboard(self):
         hoomd.context.initialize()
-        model_dir = build_examples.benchmark_nonlist_graph()
+        model_dir = build_examples.benchmark_nonlist_graph(self.tmp)
         with hoomd.htf.tfcompute(model_dir, write_tensorboard=True) as tfcompute:
             system = hoomd.init.create_lattice(unitcell=hoomd.lattice.sq(a=4.0),
                                                n=[32, 32])
@@ -127,7 +139,7 @@ class test_compute(unittest.TestCase):
 
 
     def test_trainable(self):
-        model_dir = build_examples.trainable_graph(9 - 1)
+        model_dir = build_examples.trainable_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir,
                                  write_tensorboard=True) as tfcompute:
             hoomd.context.initialize()
@@ -146,7 +158,7 @@ class test_compute(unittest.TestCase):
                                'Checkpoint files not being created.')
 
     def test_bootstrap(self):
-        model_dir = build_examples.trainable_graph(9 - 1)
+        model_dir = build_examples.trainable_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(
             model_dir, bootstrap=build_examples.bootstrap_graph(
                 9 - 1, model_dir),
@@ -165,7 +177,7 @@ class test_compute(unittest.TestCase):
             hoomd.run(5)
 
     def test_incomplete_bootstrap(self):
-        model_dir = build_examples.trainable_graph(9 - 1)
+        model_dir = build_examples.trainable_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(
             model_dir, bootstrap=build_examples.bootstrap_graph(
                 9 - 1, model_dir),
@@ -184,7 +196,7 @@ class test_compute(unittest.TestCase):
             hoomd.run(5)
 
     def test_print(self):
-        model_dir = build_examples.print_graph(9 - 1)
+        model_dir = build_examples.print_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -203,7 +215,7 @@ class test_compute(unittest.TestCase):
                 hoomd.run(2)
 
     def test_noforce_graph(self):
-        model_dir = build_examples.noforce_graph()
+        model_dir = build_examples.noforce_graph(self.tmp)
         hoomd.context.initialize()
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             N = 3 * 3
@@ -224,7 +236,7 @@ class test_compute(unittest.TestCase):
 
 
     def test_wrap(self):
-        model_dir = build_examples.wrap_graph()
+        model_dir = build_examples.wrap_graph(self.tmp)
         hoomd.context.initialize()
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             system = hoomd.init.create_lattice(
@@ -238,7 +250,7 @@ class test_compute(unittest.TestCase):
 
 
     def test_feeddict_func(self):
-        model_dir = build_examples.feeddict_graph()
+        model_dir = build_examples.feeddict_graph(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -260,7 +272,7 @@ class test_compute(unittest.TestCase):
             tf_force = tfcompute.get_forces_array()[1, :3]
 
     def test_feeddict(self):
-        model_dir = build_examples.feeddict_graph()
+        model_dir = build_examples.feeddict_graph(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -281,7 +293,7 @@ class test_compute(unittest.TestCase):
 
     def test_lj_forces(self):
         N = 3 * 3
-        model_dir = build_examples.lj_graph(N - 1)
+        model_dir = build_examples.lj_graph(N - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             T = 10
@@ -327,7 +339,7 @@ class test_compute(unittest.TestCase):
                                            lj_forces[i, j], atol=1e-5)
 
     def test_running_mean(self):
-        model_dir = build_examples.lj_running_mean(9 - 1)
+        model_dir = build_examples.lj_running_mean(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             rcut = 5.0
@@ -349,7 +361,7 @@ class test_compute(unittest.TestCase):
     def test_force_output(self):
         Ne = 5
         c = hoomd.context.initialize()
-        model_dir = build_examples.lj_force_output(Ne ** 2 - 1)
+        model_dir = build_examples.lj_force_output(Ne ** 2 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             rcut = 3.0
             system = hoomd.init.create_lattice(
@@ -381,7 +393,7 @@ class test_compute(unittest.TestCase):
                     )[:, 3], lj_energy)
 
     def test_rdf(self):
-        model_dir = build_examples.lj_rdf(9 - 1)
+        model_dir = build_examples.lj_rdf(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             rcut = 5.0
@@ -400,7 +412,7 @@ class test_compute(unittest.TestCase):
         assert np.sum(variables['avg-rdf']) > 0
 
     def test_lj_energy(self):
-        model_dir = build_examples.lj_graph(9 - 1)
+        model_dir = build_examples.lj_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -433,7 +445,7 @@ class test_compute(unittest.TestCase):
         # I can't figure out why, but since PE and forces are
         # matching exactly, I'll leave the tol
         # set that high.
-        model_dir = build_examples.lj_graph(9 - 1)
+        model_dir = build_examples.lj_graph(9 - 1, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             hoomd.context.initialize()
             N = 3 * 3
@@ -484,9 +496,15 @@ class test_compute(unittest.TestCase):
 
 
 class test_mol_batching(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryFile()
+
+    def tearDown(self):
+        self.tmp.close()
+
     def test_single_atom(self):
         hoomd.context.initialize()
-        model_dir = build_examples.lj_mol(9 - 1, 8)
+        model_dir = build_examples.lj_mol(9 - 1, 8, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             N = 3 * 3
             NN = N - 1
@@ -501,7 +519,7 @@ class test_mol_batching(unittest.TestCase):
 
     def test_single_atom_batched(self):
         hoomd.context.initialize()
-        model_dir = build_examples.lj_mol(9 - 1, 8, '/tmp/test-lj-batch-lj')
+        model_dir = build_examples.lj_mol(9 - 1, 8, self.tmp)
         with hoomd.htf.tfcompute(model_dir, _mock_mode=True) as tfcompute:
             N = 3 * 3
             NN = N - 1
@@ -517,7 +535,7 @@ class test_mol_batching(unittest.TestCase):
 
     def test_single_atom_malformed(self):
         hoomd.context.initialize()
-        model_dir = build_examples.lj_mol(9 - 1, 8, '/tmp/test-lj-malf-lj')
+        model_dir = build_examples.lj_mol(9 - 1, 8, self.tmp)
         with hoomd.htf.tfcompute(model_dir, _mock_mode=True) as tfcompute:
             N = 3 * 3
             NN = N - 1
@@ -533,7 +551,7 @@ class test_mol_batching(unittest.TestCase):
 
     def test_multi_atom(self):
         hoomd.context.initialize()
-        model_dir = build_examples.lj_mol(9 - 1, 8, '/tmp/test-lj-multi-lj')
+        model_dir = build_examples.lj_mol(9 - 1, 8, self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             N = 3 * 3
             NN = N - 1
@@ -550,7 +568,7 @@ class test_mol_batching(unittest.TestCase):
 
     def test_mol_force_output(self):
         hoomd.context.initialize()
-        model_dir = build_examples.mol_force()
+        model_dir = build_examples.mol_force(self.tmp)
         with hoomd.htf.tfcompute(model_dir) as tfcompute:
             system = hoomd.init.create_lattice(unitcell=hoomd.lattice.sq(a=4.0),
                                                n=[3, 3])

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -36,10 +36,10 @@ def compute_forces(system, rcut):
 
 class test_access(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_access(self):
         model_dir = build_examples.simple_potential(self.tmp)
@@ -71,10 +71,10 @@ class test_access(unittest.TestCase):
 
 class test_compute(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_force_overwrite(self):
         model_dir = build_examples.simple_potential(self.tmp)
@@ -496,11 +496,12 @@ class test_compute(unittest.TestCase):
 
 
 class test_mol_batching(unittest.TestCase):
+
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_single_atom(self):
         hoomd.context.initialize()

--- a/htf/test-py/test_utils.py
+++ b/htf/test-py/test_utils.py
@@ -7,12 +7,6 @@ import build_examples
 import tempfile
 
 class test_loading(unittest.TestCase):
-    def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
-
-    def tearDown(self):
-        self.tmp.close()
-
     def test_load_variables(self):
         model_dir = self.tmp
         # make model that does assignment
@@ -38,7 +32,7 @@ class test_loading(unittest.TestCase):
 
 class test_mappings(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
         # build system using example from hoomd
         hoomd.context.initialize()
         snapshot = hoomd.data.make_snapshot(N=10,
@@ -62,7 +56,7 @@ class test_mappings(unittest.TestCase):
         self.system = hoomd.init.read_snapshot(snapshot)
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_find_molecules(self):
         # test out mapping
@@ -243,10 +237,10 @@ class test_mappings(unittest.TestCase):
 
 class test_bias(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryFile()
+        self.tmp = tempfile.mkdtemp()
 
     def tearDown(self):
-        self.tmp.close()
+        shutil.rmtree(self.tmp)
 
     def test_eds(self):
         T = 1000


### PR DESCRIPTION
Strategy: Using tempfile.TemporaryFile(). Inside the unittest class, the execute order is setUp() -> test1() -> tearDown() and then setUp() -> test2() -> tearDown() ... So we only need to set one temporary file.(instead of a temporary folder)

add this block to each test class:

```
def setUp(self):
    self.tmp = tempfile.TemporaryFile()
def tearDown(self):
    self.tmp.close() //automatically remove tmp file
```

change the directory of every methods from build_examples to self.tmp (inside test class)