### PR TITLE
Increased checkpoint max to 1 million

### DIFF
--- a/htf/tfmanager.py
+++ b/htf/tfmanager.py
@@ -11,7 +11,7 @@ import cProfile
 import queue
 import time
 
-saver_args = {'max_to_keep': 1000}
+saver_args = {'max_to_keep': 1000000}
 
 
 def main(q, write_tensorboard=False, profile=False):

--- a/sphinx-docs/source/issues.rst
+++ b/sphinx-docs/source/issues.rst
@@ -3,8 +3,18 @@
 Known Issues
 ============
 
-The following is a list of known issues. To report another issue,
-please use the `issue tracker <https://github.com/ur-whitelab/hoomd-tf/issues>`__.
+The following is a list of known issues which have no solution. To
+report issues in general, please use the `issue tracker
+<https://github.com/ur-whitelab/hoomd-tf/issues>`__.
+
+.. _checkpoint_number:
+
+Using Positions
+---------------
+
+The maximum number of checkpoints you can save is limited
+to 1 million. Edit the source in `tfmanager.py` if this
+is too low for your needs
 
 .. _positions_issues:
 


### PR DESCRIPTION
Small change. Just added to known issues that we can save limited checkpoints and upped number from 1,000 to 1 million. 