### PR TITLE
Mol batching changes

### DIFF
--- a/htf/TensorflowCompute.cc
+++ b/htf/TensorflowCompute.cc
@@ -306,17 +306,6 @@ void TensorflowCompute<M>::prepareNeighbors(unsigned int batch_offset, unsigned 
         const unsigned int size = (unsigned int)h_n_neigh.data[i];
         unsigned int j = 0;
 
-        if (m_nneighs < size)
-            {
-            m_exec_conf->msg->error()
-                << "Overflow in nlist! Only "
-                << m_nneighs
-                << " space but there are "
-                << size
-                << " neighbors."
-                << std::endl;
-            throw std::runtime_error("Nlist Overflow");
-            }
         for (; j < size; j++)
             {
 
@@ -331,6 +320,19 @@ void TensorflowCompute<M>::prepareNeighbors(unsigned int batch_offset, unsigned 
             // apply periodic boundary conditions
             dx = box.minImage(dx);
             if (dx.x * dx.x + dx.y * dx.y + dx.z * dx.z > m_r_cut * m_r_cut) continue;
+
+	    if (nnoffset[bi] >= size)
+	      {
+		m_exec_conf->msg->error()
+		  << "Overflow in nlist! Only "
+		  << m_nneighs
+		  << " space but there are "
+		  << size
+		  << " neighbors."
+		  << std::endl;
+		throw std::runtime_error("Nlist Overflow");
+	      }
+
             buffer[bi * m_nneighs + nnoffset[bi]].x = dx.x;
             buffer[bi * m_nneighs + nnoffset[bi]].y = dx.y;
             buffer[bi * m_nneighs + nnoffset[bi]].z = dx.z;

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -296,7 +296,7 @@ class graph_builder:
         self.out_nodes.append([store_op, save_period])
 
 
-    def compute_forces(self, energy, virial=None, positions=None,
+    def compute_forces(self, energy, virial=None, positions=False,
                        nlist=None):
         R""" Computes pairwise or position-dependent forces (field) given
         a potential energy function that computes per-particle
@@ -308,8 +308,11 @@ class graph_builder:
             if the graph outputs forces. Can be set manually instead. Note
             that the virial term that depends on positions is not computed.
         :type virial: bool
-        :param positions: Defaults to ``None``. Particle positions tensor to use
-            for force calculations. If not specified, uses ``self.positions``.
+        :param positions: Defaults to ``False``. Particle positions tensor to use
+            for force calculations. If set to ``None``, uses ``self.positions``. If
+            set to ``False`` (default), no position dependent forces will be computed.
+            Only pairwise forces from neighbor list will be applied. If set to a 
+            tensor, that tensor will be used instead of ``self.positions``.
         :type positions: tensor
         :param nlist: Defaults to ``None``. Particle-wise neighbor list to use
             for force calculations. If not specified, uses ``self.nlist``.

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -418,6 +418,7 @@ class graph_builder:
         self.mol_indices = tf.placeholder(tf.int32,
                                           shape=[None, MN],
                                           name='htf-molecule-index')
+
         self.rev_mol_indices = tf.placeholder(tf.int32,
                                               shape=[None, 2],
                                               name='htf-reverse-molecule-index')

--- a/htf/tfarraycomm.py
+++ b/htf/tfarraycomm.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Andrew White at the University of Rochester
 # This file is part of the Hoomd-Tensorflow plugin developed by Andrew White
 
-import hoomd.htf._htf as _htf
+from hoomd.htf import _htf
 import numpy as np
 import hoomd
 

--- a/htf/utils.py
+++ b/htf/utils.py
@@ -430,7 +430,7 @@ def eds_bias(cv, set_point, period, learning_rate=1, cv_scale=1, name='eds'):
         update_mask = tf.cast(tf.equal(n, period - 1), tf.float32)
         gradient = update_mask * -  2 * \
             (cv - set_point) * ssd / period // 2 / cv_scale
-        optimizer = tf.train.AdamOptimizer(learning_rate)
+        optimizer = tf.train.AdagradOptimizer(learning_rate)
         update_alpha = tf.cond(tf.equal(n, period - 1),
                                lambda: optimizer.apply_gradients([(gradient,
                                                                    alpha)]),


### PR DESCRIPTION
This makes three changes to help with @geemi725's project:

1. Made nlist overflows less often in CPU by waiting to check after pruning with rcut
2. Making molecule indices frozen (unable to change during simulation) to make saving/computations easier
3. Some EDS changes to make it more robust to name clashes and removed an unnecessary cast.