### PR TITLE
Added checks for neighbor list overflow and prevented GPU segfaults

### DIFF
--- a/htf/TensorflowCompute.cc
+++ b/htf/TensorflowCompute.cc
@@ -293,8 +293,9 @@ void TensorflowCompute<M>::prepareNeighbors(unsigned int batch_offset, unsigned 
     // need for periodic image correction
     const BoxDim& box = m_pdata->getBox();
 
-    // for each particle
-    int bi = 0;
+    // for each particle adjust nlist
+    // bi is buffer index
+    unsigned int bi = 0; 
     for (unsigned int i = batch_offset; i < batch_offset + batch_size; i++, bi++)
         {
         // access the particle's position and type (MEM TRANSFER: 4 scalars)
@@ -321,6 +322,7 @@ void TensorflowCompute<M>::prepareNeighbors(unsigned int batch_offset, unsigned 
             dx = box.minImage(dx);
             if (dx.x * dx.x + dx.y * dx.y + dx.z * dx.z > m_r_cut * m_r_cut) continue;
 
+	    /*
 	    if (nnoffset[bi] >= size)
 	      {
 		m_exec_conf->msg->error()
@@ -332,7 +334,10 @@ void TensorflowCompute<M>::prepareNeighbors(unsigned int batch_offset, unsigned 
 		  << std::endl;
 		throw std::runtime_error("Nlist Overflow");
 	      }
-
+	    */
+	    // prevent segmentation fault
+	    // we check for this in TF ops
+            nnoffset[bi] %= size;
             buffer[bi * m_nneighs + nnoffset[bi]].x = dx.x;
             buffer[bi * m_nneighs + nnoffset[bi]].y = dx.y;
             buffer[bi * m_nneighs + nnoffset[bi]].z = dx.z;

--- a/htf/TensorflowCompute.cu
+++ b/htf/TensorflowCompute.cu
@@ -118,8 +118,7 @@ __global__ void htf_gpu_reshape_nlist_kernel(Scalar4* dest,
     else
         next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx);
 
-    // loop over neighbors
-    assert(n_neigh <= NN);
+    unsigned int dest_idx = 0;
     for (int neigh_idx = 0; neigh_idx < n_neigh; neigh_idx++)
         {
 
@@ -149,11 +148,15 @@ __global__ void htf_gpu_reshape_nlist_kernel(Scalar4* dest,
 
         if (rsq < (rmax * rmax))
         {
-            dest[(idx - offset) * NN + neigh_idx].x = dx.x;
-            dest[(idx - offset) * NN + neigh_idx].y = dx.y;
-            dest[(idx - offset) * NN + neigh_idx].z = dx.z;
-            dest[(idx - offset) * NN + neigh_idx].w = static_cast<Scalar> (typej);
-
+            dest[(idx - offset) * NN + dest_idx].x = dx.x;
+            dest[(idx - offset) * NN + dest_idx].y = dx.y;
+            dest[(idx - offset) * NN + dest_idx].z = dx.z;
+            dest[(idx - offset) * NN + dest_idx].w = static_cast<Scalar> (typej);
+	    dest_idx += 1;
+	    // prevent overflow. Note this should not happen
+	    // we check for it later, but this prevents 
+	    // illegeal mem access
+	    dest_idx %= NN;
             }
         }
     }

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -13,6 +13,8 @@ class graph_builder:
         :type nneighbor_cutoff: int
         :param output_forces: True if your graph will compute forces to be used in TensorFlow
         :type output_forces: bool
+        :type check_nlist: bool
+        :param check_nlist: True will raise error if neighbor list overflows (nneighbor_cutoff too low)
     """
     # \internal
     # \brief Initializes the graphbuilder class

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -16,7 +16,7 @@ class graph_builder:
     """
     # \internal
     # \brief Initializes the graphbuilder class
-    def __init__(self, nneighbor_cutoff, output_forces=True):
+    def __init__(self, nneighbor_cutoff, output_forces=True, check_nlist=False):
         R""" Build the TensorFlow graph that will be used during the HOOMD run.
         """
         # clear any previous graphs
@@ -52,6 +52,13 @@ class graph_builder:
                                                 true_fn=lambda: tf.constant(1),
                                                 false_fn=lambda: tf.constant(0)))
         self.out_nodes = [self.update_batch_index_op]
+
+        # add check for nlist size
+        if check_nlist:
+            NN = tf.reduce_max(tf.reduce_sum(tf.cast(self.nlist[:, :, 0] > 0, tf.dtypes.int32), axis=1), axis=0)
+            check_op = tf.Assert(tf.less(NN, nneighbor_cutoff), ['Neighbor list is full!'])
+            self.out_nodes.append(check_op)
+        
 
     ## \var atom_number
     # \internal

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -14,8 +14,10 @@ class graph_builder:
         :param output_forces: True if your graph will compute forces to be used in TensorFlow
         :type output_forces: bool
         :type check_nlist: bool
-        :param check_nlist: True will raise error if neighbor list overflows (nneighbor_cutoff too low)
+        :param check_nlist: True will raise error if neighbor 
+                            list overflows (nneighbor_cutoff too low)
     """
+
     # \internal
     # \brief Initializes the graphbuilder class
     def __init__(self, nneighbor_cutoff, output_forces=True, check_nlist=False):
@@ -57,7 +59,9 @@ class graph_builder:
 
         # add check for nlist size
         if check_nlist:
-            NN = tf.reduce_max(tf.reduce_sum(tf.cast(self.nlist[:, :, 0] > 0, tf.dtypes.int32), axis=1), axis=0)
+            NN = tf.reduce_max(tf.reduce_sum(tf.cast(self.nlist[:, :, 0] > 0, 
+                                                     tf.dtypes.int32), axis=1), 
+                                                     axis=0)
             check_op = tf.Assert(tf.less(NN, nneighbor_cutoff), ['Neighbor list is full!'])
             self.out_nodes.append(check_op)
         

--- a/htf/graphbuilder.py
+++ b/htf/graphbuilder.py
@@ -14,7 +14,7 @@ class graph_builder:
         :param output_forces: True if your graph will compute forces to be used in TensorFlow
         :type output_forces: bool
         :type check_nlist: bool
-        :param check_nlist: True will raise error if neighbor 
+        :param check_nlist: True will raise error if neighbor
                             list overflows (nneighbor_cutoff too low)
     """
 
@@ -59,12 +59,12 @@ class graph_builder:
 
         # add check for nlist size
         if check_nlist:
-            NN = tf.reduce_max(tf.reduce_sum(tf.cast(self.nlist[:, :, 0] > 0, 
-                                                     tf.dtypes.int32), axis=1), 
-                                                     axis=0)
+            NN = tf.reduce_max(tf.reduce_sum(tf.cast(self.nlist[:, :, 0] > 0,
+                                                     tf.dtypes.int32), axis=1),
+                               axis=0)
             check_op = tf.Assert(tf.less(NN, nneighbor_cutoff), ['Neighbor list is full!'])
             self.out_nodes.append(check_op)
-        
+
 
     ## \var atom_number
     # \internal

--- a/htf/test-py/build_examples.py
+++ b/htf/test-py/build_examples.py
@@ -113,8 +113,8 @@ def benchmark_nonlist_graph(directory='/tmp/benchmark-nonlist-model'):
     return directory
 
 
-def lj_graph(NN, directory='/tmp/test-lj-potential-model'):
-    graph = htf.graph_builder(NN)
+def lj_graph(NN, directory='/tmp/test-lj-potential-model', **kw_args):
+    graph = htf.graph_builder(NN, **kw_args)
     nlist = graph.nlist[:, :, :3]
     # get r
     r = tf.norm(nlist, axis=2)

--- a/htf/test-py/test_tensorflow.py
+++ b/htf/test-py/test_tensorflow.py
@@ -56,7 +56,7 @@ class test_access(unittest.TestCase):
                 a2=[0, 6, 0],
                 a3=[0, 0, 6],
                 position=[[2, 2, 2], [1, 3, 1], [3, 1, 1]],
- type_name=['A', 'B', 'C'])
+                type_name=['A', 'B', 'C'])
             system = hoomd.init.create_lattice(unitcell=cell, n=5)
             nlist = hoomd.md.nlist.cell(check_period=1)
             hoomd.md.integrate.mode_standard(dt=0.005)
@@ -623,6 +623,7 @@ class test_saving(unittest.TestCase):
         # now load
         vars = hoomd.htf.load_variables(model_dir, ['v1', 'v2'])
 
+
 class test_nlist(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -630,8 +631,7 @@ class test_nlist(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp)
 
-
-    def _test_cpu_overflow(self):        
+    def _test_cpu_overflow(self):
         '''Use too small neighbor list and ensure error is thrown
         TODO: It works, but the tfmanager thread early exit causes main thread to hang
         '''
@@ -653,7 +653,6 @@ class test_nlist(unittest.TestCase):
             with self.assertRaises(tf.errors.InvalidArgumentError):
                 hoomd.run(2)
 
-        
 
 if __name__ == '__main__':
     unittest.main()

--- a/sphinx-docs/source/building_the_graph.rst
+++ b/sphinx-docs/source/building_the_graph.rst
@@ -10,11 +10,15 @@ To construct a graph, create a :py:class:`graphbuilder.graph_builder` instance:
     import hoomd.htf as htf
     graph = htf.graph_builder(NN, output_forces)
 
-where ``NN`` is the maximum number of nearest neighbors to consider (can
-be 0) and ``output_forces`` indicates if the graph will output forces to
-use in the simulation. After building the ``graph``, it will have five
-tensors as attributes that can be used when constructing the TensorFlow graph:
-``nlist``, ``positions``, ``box``, ``box_size``, and ``forces``:
+where ``NN`` is the maximum number of nearest neighbors to consider
+(can be 0). This is an upper-bound, so choose a large number. If you
+are unsure, you can guess and add ``check_nlist = True``. This will
+cause the program to halt if you choose too low.
+``output_forces`` indicates if the graph will output forces to use in
+the simulation. After building the ``graph``, it will have five
+tensors as attributes that can be used when constructing the
+TensorFlow graph: ``nlist``, ``positions``, ``box``, ``box_size``, and
+``forces``:
 
 * ``nlist`` is an ``N`` x ``NN`` x 4 tensor containing the nearest
   neighbors. An entry of all zeros indicates that less than ``NN`` nearest


### PR DESCRIPTION
Addresses #191 providing better warning about nlist overflows and prevents segfaults from this in GPU. Note that the unit test is disabled (remove underscore to test) because it hangs when it correctly throws an error in TF due to a deadlocking issue on threads. I haven't been able to fix this, but thought it was better to show exception 